### PR TITLE
removed handlebars as a dependency from nodebootstrap-server

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,8 +39,6 @@ exports.setup = function(callback) {
   
   app.use(require('compression')());
 
-  app.set('views', __dirname + '/views');
-
   var bodyParser = require('body-parser');
   // parse application/x-www-form-urlencoded
   app.use(bodyParser.urlencoded({extended: true}))  

--- a/app.js
+++ b/app.js
@@ -2,7 +2,6 @@ var express = require('express')
   , app     = express()
   , log     = require('metalogger')()
   , cluster = require('cluster')
-  , hbs     = require('hbs')
   , CONF    = require('config');
 
 exports = module.exports;
@@ -41,8 +40,6 @@ exports.setup = function(callback) {
   app.use(require('compression')());
 
   app.set('views', __dirname + '/views');
-  app.set('view engine', 'handlebars');
-  app.engine('handlebars', hbs.__express);
 
   var bodyParser = require('body-parser');
   // parse application/x-www-form-urlencoded

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   , "response-time"      : "2.x"
   
   , "config"             : "*"
-  , "hbs"                : "2.x"
   , "less"               : "1.x"
   , "less-middleware"    : "1.0.x"
   , "underscore"         : "1.x"


### PR DESCRIPTION
Ran into an error when I tried to switch my view engine to jade and remove handlebars as a dep in a project built using nodebootstrap. I think ideally, handlebars, less, and less-middleware should go into the nodebootstrap module, while nodebootstrap-server should just remain a clean server.