### PR TITLE
Exporting the handlebars instance for helpers and other fun

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,9 @@ var express = require('express')
 
 exports = module.exports;
 
+// Export the handlebars instance so that helpers can be registered for templates.
+exports.hbs = hbs;
+
 exports.setup = function(callback) {
   configure_logging();
     


### PR DESCRIPTION
I needed the ability to register helpers for handlebars which meant grabbing a hold of the same instance that's being set as the express view engine.  This was working well for me but curious if you think there might be a better way to handle it.