### PR TITLE
Export http module from app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,13 +3,14 @@ var express = require('express')
   , log     = require('metalogger')()
   , cluster = require('cluster')
   , hbs     = require('hbs')
-  , CONF    = require('config');
+  , CONF    = require('config')
+  , http    = require('http');
 
 exports = module.exports;
 
 exports.setup = function(callback) {
   configure_logging();
-    
+
   var isClusterMaster = (cluster.isMaster && (process.env.NODE_CLUSTERED == 1));
 
   var is_http_thread = true;
@@ -26,7 +27,8 @@ exports.setup = function(callback) {
   }
 
   if (is_http_thread) {
-    app.listen(CONF.app.port);
+    http = http.createServer(app);
+    http.listen(CONF.app.port);
   }
 
 // If we are not running a cluster at all:
@@ -35,44 +37,43 @@ exports.setup = function(callback) {
   }
 
   module.parent.exports.setAppDefaults(app);
-  callback(app);
-
+  callback(app, http);
 };
 
 module.parent.exports.setAppDefaults = function(initapp) {
-  
+
   var someapp = initapp || express();
-  
+
   // var root_dir = require('path').dirname(module.parent.filename);
   var root_dir = require('path').dirname(require.main.filename);
-  
+
   /** http://webapplog.com/migrating-express-js-3-x-to-4-x-middleware-route-and-other-changes/ **/
-  
+
   someapp.use(require('compression')());
-  
+
   //console.log("---------- " + __dirname + '/views');
   //console.log("~~~~~~~~~~~~~~~~~~" + root_dir + '/views');
-  
+
   someapp.set('view engine', 'handlebars');
   someapp.engine('handlebars', hbs.__express);
-  someapp.set('views', root_dir + '/views'); 
+  someapp.set('views', root_dir + '/views');
   //app.set("view options", { layout: appDir + '/views' });
-  
-  
+
+
   var bodyParser = require('body-parser');
   // parse application/x-www-form-urlencoded
-  someapp.use(bodyParser.urlencoded({extended: true}))  
+  someapp.use(bodyParser.urlencoded({extended: true}))
   // parse application/json
   someapp.use(bodyParser.json())
-  
+
   someapp.use(require('connect-multiparty')());
   someapp.use(require('method-override')('X-HTTP-Method-Override'));
-  
+
   if (('app' in CONF) && ('csrf' in CONF.app) && CONF.app.csrf === true) {
     someapp.use(require('csurf')());
     log.notice("CSRF protection turned on. ATTENTION: this may create problems if you use NodeBootstrap to build APIs!");
   }
-  
+
   // This is not needed if you handle static files with, say, Nginx (recommended in production!)
   // Additionally you should probably pre-compile your LESS stylesheets in production
   // Last, but not least: Express' default error handler is very useful in dev, but probably not in prod.
@@ -80,16 +81,16 @@ module.parent.exports.setAppDefaults = function(initapp) {
     var pub_dir = CONF.app.pub_dir;
     if (pub_dir[0] != '/') { pub_dir = '/' + pub_dir; } // humans are forgetful
     pub_dir = root_dir + pub_dir;
-  
+
     someapp.use(require('less-middleware')(pub_dir ));
     someapp.use(require('serve-static')(pub_dir));
     someapp.use(require('errorhandler')({ dumpExceptions: true, showStack: true }));
   }
-  
+
   // Catch-all error handler. Modify as you see fit, but don't overuse.
   // Throwing exceptions is not how we normally handle errors in Node.
   someapp.use(catchAllErrHandler);
-  
+
   if (typeof initapp === 'undefined') return someapp;
 }
 


### PR DESCRIPTION
Certain modules (e.g. socket.io) need access to the underlying http server instance. This patch makes them available to client code by injecting into the callback passed to `setup`.