### PR TITLE
Fix breakage when redeploying existing server.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,14 +8,18 @@ var express = require('express')
 exports = module.exports;
 
 exports.setup = function(initapp, callback) {
-
-  // fix backward compatibility shim
+  
   if (typeof callback !== 'undefined' && initapp) {
     app = initapp;
   } else if(typeof callback === 'undefined') {
+    // This is to support old clients who do not
+    //  know about the "initapp" parameter and are
+    //  only passing callback, through.
     callback = initapp;
   } else {
-    // probably we should do something here, but I'm not sure what
+    // remaining condition:
+    // if initapp is false but is actually passed
+    // the right thing to do is to ignore it.
   }
   
   configure_logging();

--- a/app.js
+++ b/app.js
@@ -9,9 +9,15 @@ exports = module.exports;
 
 exports.setup = function(initapp, callback) {
 
-  if (typeof initapp !== 'undefined' && initapp) {
+  // fix backward compatibility shim
+  if (typeof callback !== 'undefined' && initapp) {
     app = initapp;
+  } else if(typeof callback === 'undefined') {
+    callback = initapp;
+  } else {
+    // probably we should do something here, but I'm not sure what
   }
+  
   configure_logging();
 
   var isClusterMaster = (cluster.isMaster && (process.env.NODE_CLUSTERED == 1));


### PR DESCRIPTION
Older server.js files produced by nodebootstrap do not have two arguments, and this wasn't correctly checking for that case, breaking already-built but undeployed nodebootstrap-based apps (`npm install` brings in latest -server by default).