### PR TITLE
Allow app to listen on Heroku-assigned port

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,7 +46,7 @@ exports.setup = function(initapp, callback) {
 
   // If we are not running a cluster at all:
   if (!isClusterMaster && cluster.isMaster) {
-    log.notice("Express server instance listening on port " + npm ERR! code ELIFECYCLE + " OR " + CONF.app.port);
+    log.notice("Express server instance listening on port " + process.env.PORT + " OR " + CONF.app.port);
   }
 
   module.parent.exports.setAppDefaults(app);

--- a/app.js
+++ b/app.js
@@ -46,7 +46,7 @@ exports.setup = function(initapp, callback) {
 
   // If we are not running a cluster at all:
   if (!isClusterMaster && cluster.isMaster) {
-    log.notice("Express server instance listening on port " + process.env.PORT + " OR " + CONF.app.port);
+    log.notice("Express server instance listening on port " + CONF.app.port);
   }
 
   module.parent.exports.setAppDefaults(app);

--- a/app.js
+++ b/app.js
@@ -41,12 +41,12 @@ exports.setup = function(initapp, callback) {
 
   if (is_http_thread) {
     http = http.createServer(app);
-    http.listen(CONF.app.port);
+    http.listen(process.env.PORT || CONF.app.port);
   }
 
   // If we are not running a cluster at all:
   if (!isClusterMaster && cluster.isMaster) {
-    log.notice("Express server instance listening on port " + CONF.app.port);
+    log.notice("Express server instance listening on port " + npm ERR! code ELIFECYCLE + " OR " + CONF.app.port);
   }
 
   module.parent.exports.setAppDefaults(app);


### PR DESCRIPTION
From [here](http://stackoverflow.com/questions/15693192/heroku-node-js-error-web-process-failed-to-bind-to-port-within-60-seconds-of):

> Heroku dynamically assigns your app a port, so you can't set the port to a fixed number. Heroku adds the port to the env, so you can pull it from there. Switch your listen to this:
> 
> `.listen(process.env.PORT || 5000)`
> 
> That way it'll still listen to port 5000 when you test locally, but it will also work on Heroku.